### PR TITLE
Topics field and vocabulary name. Part of localgovdrupal/localgov_topics#1

### DIFF
--- a/config/install/field.storage.node.localgov_topic_classified.yml
+++ b/config/install/field.storage.node.localgov_topic_classified.yml
@@ -4,8 +4,8 @@ dependencies:
   module:
     - node
     - taxonomy
-id: node.field_topic_term
-field_name: field_topic_term
+id: node.localgov_topic_classified
+field_name: localgov_topic_classified
 entity_type: node
 type: entity_reference
 settings:

--- a/config/install/taxonomy.vocabulary.localgov_topic.yml
+++ b/config/install/taxonomy.vocabulary.localgov_topic.yml
@@ -2,6 +2,6 @@ langcode: en
 status: true
 dependencies: {  }
 name: Topic
-vid: topic
+vid: localgov_topic
 description: 'Topic tags group together related content across all services'
 weight: 0

--- a/config/optional/views.view.topics.yml
+++ b/config/optional/views.view.topics.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - taxonomy.vocabulary.topic
+    - taxonomy.vocabulary.localgov_topic
   module:
     - taxonomy
     - user
@@ -118,7 +118,7 @@ display:
           table: taxonomy_term_field_data
           field: vid
           value:
-            topic: topic
+            localgov_topic: localgov_topic
           entity_type: taxonomy_term
           entity_field: vid
           plugin_id: bundle
@@ -238,7 +238,7 @@ display:
           table: taxonomy_term_field_data
           field: vid
           value:
-            topic: topic
+            localgov_topic: localgov_topic
           entity_type: taxonomy_term
           entity_field: vid
           plugin_id: bundle


### PR DESCRIPTION
This an related branches change the primary field name, and vocabulary name. 

Rest can follow with a review as it's not as shared or distributed yet.