### PR TITLE
fix: drop Drupal 9 support

### DIFF
--- a/localgov_topics.info.yml
+++ b/localgov_topics.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Topics
 description: Topic taxonomy and related functionality for the LocalGovDrupal distribution.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - drupal:taxonomy


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

As mentioned on MT, dropping Drupal 9 from the supported list as we no longer support or test against this version