### PR TITLE
Rebuild the container when installing the module

### DIFF
--- a/localgov_topics.info.yml
+++ b/localgov_topics.info.yml
@@ -3,6 +3,7 @@ description: Topic taxonomy and related functionality for the LocalGovDrupal dis
 package: LocalGov Drupal
 type: module
 core_version_requirement: ^10 || ^11
+container_rebuild_required: true
 
 dependencies:
   - drupal:taxonomy


### PR DESCRIPTION
Fixes #34

## What does this change?

Adds `container_rebuild_required: true` to tine info.yml file to fix an error when installing the module.

## How to test

Module enables without errors and warnings whith Drupal 11.2+

